### PR TITLE
Simply ignored blockTime field for now

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -6,7 +6,7 @@
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash |>  BlockScoutWeb.AddressView.loomnify) %>
     <% else %>
       <span class="d-none d-lg-none d-xl-inline"><%= @address |>  BlockScoutWeb.AddressView.loomnify %></span>
-      <span class="d-lg-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
+      <span class="d-lg-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) |>  BlockScoutWeb.AddressView.loomnify %></span>
     <% end %>
   <% end %>
 </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -5,8 +5,8 @@
     <%= if assigns[:truncate] do %>
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash |>  BlockScoutWeb.AddressView.loomnify) %>
     <% else %>
-      <span class="d-none d-md-none d-lg-inline"><%= @address |>  BlockScoutWeb.AddressView.loomnify %></span>
-      <span class="d-md-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
+      <span class="d-none d-lg-none d-xl-inline"><%= @address |>  BlockScoutWeb.AddressView.loomnify %></span>
+      <span class="d-lg-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
     <% end %>
   <% end %>
 </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -105,7 +105,7 @@
             <span class="text-muted" data-test="address_contract_creator">
               <%= if from_address_hash do %>
                 <%= gettext "Created by" %> <%= link(
-                  trimmed_hash(from_address_hash(@address)),
+                  trimmed_hash(from_address_hash(@address))|> loomnify ,
                   to: address_path(@conn, :show, from_address_hash(@address))
                 ) %>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
@@ -12,11 +12,11 @@
       <% end %>
     <% end %>
     <span class="d-inline-block tile-type-token-transfer-short-name">
-    <%= token_transfer_amount(@token_transfer) %>
+    <%= @token_transfer |> BlockScoutWeb.AddressView.address_partial_selector(:from, @address, true) |> BlockScoutWeb.RenderHelpers.render_partial() %>
     </span>
     &rarr;
     <span class="d-inline-block tile-type-token-transfer-short-name">
-    <%= link(token_symbol(@token_transfer.token), to: token_path(BlockScoutWeb.Endpoint, :show, @token_transfer.token.contract_address_hash)) %>
+    <%= @token_transfer |> BlockScoutWeb.AddressView.address_partial_selector(:to, @address, true) |> BlockScoutWeb.RenderHelpers.render_partial() %>
     </span>
   </span>
   <span class="col-xs-12 col-lg-4 ml-3 ml-sm-0 text-truncate">

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -232,7 +232,7 @@ defmodule BlockScoutWeb.AddressView do
 
   def trimmed_hash(%Hash{} = hash) do
     string_hash = to_string(hash)
-    "loom#{String.slice(string_hash, 2..5)}–#{String.slice(string_hash, -6..-1)}"
+    "#{String.slice(string_hash, 0..5)}–#{String.slice(string_hash, -6..-1)}"
   end
 
   def trimmed_hash(_), do: ""

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -232,7 +232,7 @@ defmodule BlockScoutWeb.AddressView do
 
   def trimmed_hash(%Hash{} = hash) do
     string_hash = to_string(hash)
-    "#{String.slice(string_hash, 0..5)}–#{String.slice(string_hash, -6..-1)}"
+    "loom#{String.slice(string_hash, 2..5)}–#{String.slice(string_hash, -6..-1)}"
   end
 
   def trimmed_hash(_), do: ""

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -162,6 +162,9 @@ defmodule EthereumJSONRPC.Log do
         "transactionIndex" => 0
       }
 
+  Loom includes a `"blockTime"` key whose value could be converted to an integer, but since it's not
+  used by Blockscout it's just kept untransformed (thought it should probably be discarded entirely).
+
   """
   def to_elixir(log) when is_map(log) do
     Enum.into(log, %{}, &entry_to_elixir/1)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -167,7 +167,7 @@ defmodule EthereumJSONRPC.Log do
     Enum.into(log, %{}, &entry_to_elixir/1)
   end
 
-  defp entry_to_elixir({key, _} = entry) when key in ~w(address blockHash data removed topics transactionHash type),
+  defp entry_to_elixir({key, _} = entry) when key in ~w(address blockHash data removed topics transactionHash type blockTime),
     do: entry
 
   defp entry_to_elixir({key, quantity}) when key in ~w(blockNumber logIndex transactionIndex transactionLogIndex) do


### PR DESCRIPTION
I tested this change by built loomchain from the commit that have `blockTime` field logs.
Then deploy and call EVM contract and the blockscout does not throw any errors.
ref: https://github.com/loomnetwork/blockscout/issues/72