### PR TITLE
Ignore error on pg_notify

### DIFF
--- a/apps/explorer/lib/explorer/chain/events/db_sender.ex
+++ b/apps/explorer/lib/explorer/chain/events/db_sender.ex
@@ -21,6 +21,11 @@ defmodule Explorer.Chain.Events.DBSender do
   end
 
   defp send_notify(payload) do
-    Repo.query!("select pg_notify('chain_event', $1::text);", [payload])
+    try do
+      Repo.query!("select pg_notify('chain_event', $1::text);", [payload])
+    rescue
+      postgrex_error in Postgrex.Error ->
+        {:error, %{exception: postgrex_error}}
+    end
   end
 end


### PR DESCRIPTION
`blockscout` sometimes use Postgres notify Inappropriately (payload exceed 8000 bytes).
This PR will ignore the error message.