### PR TITLE
Change log level of BufferedTask queue message from warn to debug

### DIFF
--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -396,7 +396,7 @@ defmodule Indexer.BufferedTask do
           new_bound_queue
 
         {%BoundQueue{maximum_size: maximum_size} = new_bound_queue, remaining_entries} ->
-          Logger.warn(fn ->
+          Logger.debug(fn ->
             [
               "BufferedTask ",
               process(self()),


### PR DESCRIPTION
This message spams the logs, and there isn't much we can do about it anyway.