### PR TITLE
Disable wobserver and admin panel routes by default

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -93,6 +93,8 @@ config :wobserver,
 config :block_scout_web, BlockScoutWeb.ApiRouter,
   writing_enabled: System.get_env("DISABLE_WRITE_API") != "true",
   reading_enabled: System.get_env("DISABLE_READ_API") != "true"
+  wobserver_enabled: System.get_env("WOBSERVER_ENABLED") == "true"
+  admin_panel_enabled: System.get_env("ADMIN_PANEL_ENABLED") == "true"
 
 config :block_scout_web, BlockScoutWeb.WebRouter, enabled: System.get_env("DISABLE_WEBAPP") != "true"
 

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -92,8 +92,8 @@ config :wobserver,
 
 config :block_scout_web, BlockScoutWeb.ApiRouter,
   writing_enabled: System.get_env("DISABLE_WRITE_API") != "true",
-  reading_enabled: System.get_env("DISABLE_READ_API") != "true"
-  wobserver_enabled: System.get_env("WOBSERVER_ENABLED") == "true"
+  reading_enabled: System.get_env("DISABLE_READ_API") != "true",
+  wobserver_enabled: System.get_env("WOBSERVER_ENABLED") == "true",
   admin_panel_enabled: System.get_env("ADMIN_PANEL_ENABLED") == "true"
 
 config :block_scout_web, BlockScoutWeb.WebRouter, enabled: System.get_env("DISABLE_WEBAPP") != "true"

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -7,7 +7,10 @@ defmodule BlockScoutWeb.Endpoint do
   end
 
   socket("/socket", BlockScoutWeb.UserSocket, websocket: [timeout: 45_000])
-  socket("/wobserver", Wobserver.Web.PhoenixSocket)
+
+  if Application.get_env(:block_scout_web, ApiRouter)[:wobserver_enabled] do
+    socket("/wobserver", Wobserver.Web.PhoenixSocket)
+  end
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -4,8 +4,13 @@ defmodule BlockScoutWeb.Router do
   alias BlockScoutWeb.Plug.GraphQL
   alias BlockScoutWeb.{ApiRouter, WebRouter}
 
-  forward("/wobserver", Wobserver.Web.Router)
-  forward("/admin", BlockScoutWeb.AdminRouter)
+  if Application.get_env(:block_scout_web, ApiRouter)[:wobserver_enabled] do
+    forward("/wobserver", Wobserver.Web.Router)
+  end
+
+  if Application.get_env(:block_scout_web, ApiRouter)[:admin_panel_enabled] do
+    forward("/admin", BlockScoutWeb.AdminRouter)
+  end
 
   pipeline :browser do
     plug(:accepts, ["html"])


### PR DESCRIPTION
## Motivation

These routes should never have been public facing by default since they could leak potentially sensitive config info.

## Changelog

### Enhancements

- wobserver route is now disabled by default, can be re-enabled by setting env var `WOBSERVER_ENABLED` to `true`.
- admin route is now disable by default, can be re-enabled by setting env var `ADMIN_PANEL_ENABLED` to `true`.